### PR TITLE
Fix "s3_website help [subcommand]"

### DIFF
--- a/bin/s3_website
+++ b/bin/s3_website
@@ -124,7 +124,7 @@ class Cli < Thor
     end
   end
 
-  def help
+  def help(cmd = nil)
     version
     puts
     super


### PR DESCRIPTION
- When the help method does not accept an argument, Thor gem will error. An optional argument allows it to work with or without a subcommand

**Before**

```bash
> ./bin/s3_website help push
ERROR: "s3_website help" was called with arguments ["push"]
Usage: "s3_website help [COMMAND]"
```


**After**
```bash
> ./bin/s3_website help push
s3_website_revived 4.0.3.dev

Usage:
  s3_website push

Options:
  [--site=SITE]                # The directory where your website files are. When not defined, s3_website will look for the site in either _site or public/output.
  [--config-dir=CONFIG-DIR]    # The directory where your config file is. When not defined, s3_website will look in the current working directory.
  [--verbose], [--no-verbose]  # Print verbose output
  [--force]                    # Skip diff calculation and push all the files. This option is useful when you need to update metadata on the S3 objects.
  [--dry-run], [--no-dry-run]  # Run the operation without actually making the modifications. When this switch is on, changes will not be applied on the S3 website. They will be only printed to the console.

Description:
  `s3_website push` will upload new and changes files to S3. It will also delete from S3 the files that you
  no longer have locally.
```
